### PR TITLE
Adding missing /pg volume mount from radarr/plex/emby

### DIFF
--- a/programs/emby/app.yml
+++ b/programs/emby/app.yml
@@ -42,6 +42,7 @@
           - '{{path.stdout}}:{{path.stdout}}'
           - '/mnt:/mnt'
           - '/pg/unity:/unity'
+	  - '/pg:/pg'
 
     - name: 'Setting PG ENV'
       set_fact:

--- a/programs/plex/app.yml
+++ b/programs/plex/app.yml
@@ -83,6 +83,7 @@
           - '{{path.stdout}}:{{path.stdout}}'
           - '/etc/localtime:/etc/localtime:ro'
           - '/pg/unity:/unity'
+          - '/pg:/pg'
 
     ########################################## Secure Connections
     - name: 'Secure Connections'

--- a/programs/radarr/app.yml
+++ b/programs/radarr/app.yml
@@ -37,6 +37,7 @@
           - '{{path.stdout}}:{{path.stdout}}'
           - '/mnt:/mnt'
           - '/pg/unity:/unity'
+          - '/pg:/pg'
 
     - name: 'Setting PG ENV'
       set_fact:


### PR DESCRIPTION
v9 Docs say to use /pg/unity for Sonarr/Radarr/Plex etc but the only program that had this mount point so far was Sonarr. Have added the missing mount for Radarr/Plex/Emby for now.