### PR TITLE
fix: watchtower refreshing all apps

### DIFF
--- a/programs/watchtower/app.yml
+++ b/programs/watchtower/app.yml
@@ -10,7 +10,7 @@
   gather_facts: false
   tasks:
     - name: Pull Stored Data
-      shell: 'cat /pg/var/app.list'
+      shell: 'cat /pg/tmp/watchtower.set'
       register: programs
 
     - name: Deploy watchtower


### PR DESCRIPTION
The Ansible script is loading the programs from the fixed list instead of from the customized list generated from the menu.

Fixes #8 